### PR TITLE
Amending instructions to reflect flatten-maven-plugin configuration change

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ See [JEP-305](https://github.com/jenkinsci/jep/blob/master/jep/305/README.adoc) 
 ## Usage in plugin POMs
 
 Since most Jenkins repositories host plugins, this use case will be documented first.
-You must be using parent POM version [3.9](https://github.com/jenkinsci/plugin-pom/blob/840ac3020a0a243dd243ed7156a22dae1e3c35fe/CHANGELOG.md#39) or later.
+You must be using parent POM version [3.10](https://github.com/jenkinsci/plugin-pom/blob/master/CHANGELOG.md) or later.
 
 ### Enabling consumption of incrementals
 
@@ -72,7 +72,6 @@ Now run
 ```bash
 mkdir -p .mvn
 echo -Pmight-produce-incrementals >> .mvn/maven.config
-echo .flattened-pom.xml >> .gitignore
 ```
 
 Finally, configure [git-changelist-maven-extension](https://github.com/jglick/git-changelist-maven-extension) in `.mvn/extensions.xml`:
@@ -91,7 +90,7 @@ Finally, configure [git-changelist-maven-extension](https://github.com/jglick/gi
 You may now
 
 ```bash
-git add .mvn .gitignore pom.xml
+git add .mvn pom.xml
 ```
 
 and commit and push your edits.


### PR DESCRIPTION
Docs counterpart to https://github.com/jenkinsci/plugin-pom/pull/105.