### PR TITLE
[JENKINS-51658] add NOOP to reincrementalify

### DIFF
--- a/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/ReincrementalifyMojo.java
+++ b/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/ReincrementalifyMojo.java
@@ -56,9 +56,14 @@ public class ReincrementalifyMojo extends AbstractMojo {
     @Override public void execute() throws MojoExecutionException, MojoFailureException {
         String version = project.getVersion();
         Properties properties = project.getProperties();
-        String revision = properties.getProperty("revision", "NOOP");
-        String changelist = properties.getProperty("changelist", "NOOP");
-        if ("NOOP".equals(revision) || "NOOP".equals(changelist)) return;
+        String noop = "NOOP";
+        String revision = properties.getProperty("revision", noop);
+        String changelist = properties.getProperty("changelist", noop);
+        if (noop.equals(revision) || noop.equals(changelist)) {
+            throw new MojoExecutionException(this,
+                "Cannot use reincrementalify before incrementals is enabled",
+                "Please use 'incrementals:incrementalify' to enable incrementals");
+        }
         Matcher m = Pattern.compile("(.+)-SNAPSHOT").matcher(version);
         if (!m.matches()) {
             throw new MojoFailureException("Unexpected version: " + version);

--- a/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/ReincrementalifyMojo.java
+++ b/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/ReincrementalifyMojo.java
@@ -24,6 +24,7 @@
 
 package io.jenkins.tools.incrementals.maven;
 
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.maven.execution.MavenSession;
@@ -54,11 +55,15 @@ public class ReincrementalifyMojo extends AbstractMojo {
 
     @Override public void execute() throws MojoExecutionException, MojoFailureException {
         String version = project.getVersion();
+        Properties properties = project.getProperties();
+        String revision = properties.getProperty("revision", "NOOP");
+        String changelist = properties.getProperty("changelist", "NOOP");
+        if ("NOOP".equals(revision) || "NOOP".equals(changelist)) return;
         Matcher m = Pattern.compile("(.+)-SNAPSHOT").matcher(version);
         if (!m.matches()) {
             throw new MojoFailureException("Unexpected version: " + version);
         }
-        project.getProperties().setProperty("dollar", "$");
+        properties.setProperty("dollar", "$");
         executeMojo(plugin("org.codehaus.mojo", "versions-maven-plugin", "2.5"), "set",
             configuration(
                 element("newVersion", "${dollar}{revision}${dollar}{changelist}"),


### PR DESCRIPTION
To avoid breaking POM with `reincrementalify` if POM does not contain `revison` or `changelist` a change that https://github.com/jenkinsci/plugin-pom/pull/117 depends on