### PR TITLE
[JENKINS-51869] Drop --first-parent from rev count

### DIFF
--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.jenkins.tools.incrementals</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0-beta-4-SNAPSHOT</version>
+    </parent>
+    <artifactId>incrementals-enforcer-rules</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven.enforcer</groupId>
+            <artifactId>enforcer-rules</artifactId>
+            <version>3.0.0-M1</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/enforcer-rules/src/main/java/io/jenkins/tools/incrementals/enforcer/RequireExtensionVersion.java
+++ b/enforcer-rules/src/main/java/io/jenkins/tools/incrementals/enforcer/RequireExtensionVersion.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.jenkins.tools.incrementals.enforcer;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.enforcer.AbstractVersionEnforcer;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+
+/**
+ * Verifies that {@code git-changelist-maven-extension}, if present, is sufficiently new.
+ */
+public class RequireExtensionVersion extends AbstractVersionEnforcer {
+
+    private static final Pattern ID_PATTERN = Pattern.compile("\\QcoreExtension>io.jenkins.tools.incrementals:git-changelist-maven-extension:\\E(.+)");
+
+    @Override
+    public void execute(EnforcerRuleHelper erh) throws EnforcerRuleException {
+        Log log = erh.getLog();
+        List<AbstractMavenLifecycleParticipant> participants;
+        try {
+            participants = erh.getContainer().lookupList(AbstractMavenLifecycleParticipant.class);
+        } catch (ComponentLookupException x) {
+            log.warn(x);
+            return;
+        }
+        for (AbstractMavenLifecycleParticipant participant : participants) {
+            // TODO is there some better way of identifying a class loaded by Maven?
+            ClassLoader loader = participant.getClass().getClassLoader();
+            if (loader instanceof ClassRealm) {
+                Matcher m = ID_PATTERN.matcher(((ClassRealm) loader).getId());
+                if (m.matches()) {
+                    enforceVersion(log, "git-changelist-maven-extension", getVersion(), new DefaultArtifactVersion(m.group(1)));
+                }
+            }
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <module>lib</module>
         <module>maven-plugin</module>
         <module>git-changelist-maven-extension</module>
+        <module>enforcer-rules</module>
     </modules>
     <build>
         <plugins>


### PR DESCRIPTION
[JENKINS-51869](https://issues.jenkins-ci.org/browse/JENKINS-51869)

After release, needs a matching patch in `plugin-pom` to enforce it, something like

```xml
<rule implementation="io.jenkins.tools.incrementals.enforcer.RequireExtensionVersion">
    <version>[1.0-beta-4,)</version>
</rule>
<!-- … -->
<dependencies>
    <dependency>
        <groupId>io.jenkins.tools.incrementals</groupId>
        <artifactId>incrementals-enforcer-rules</artifactId>
        <version>1.0-beta-4</version>
    </dependency>
</dependencies>
```

and then updates to plugins already using the extension to start using the new version.