### PR TITLE
updateProperties failed to honor the updateNonincremental flag

### DIFF
--- a/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/UpdateMojo.java
+++ b/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/UpdateMojo.java
@@ -115,7 +115,7 @@ public class UpdateMojo extends AbstractVersionsDependencyUpdaterMojo {
                 getLog().info("Skipping snapshot dep " + toString(dep));
                 continue;
             }
-            if (!updateNonincremental && !version.matches(".+-rc[0-9]+[.][0-9a-f]{12}")) {
+            if (!updateNonincremental && !isIncremental(version)) {
                 getLog().debug("Skipping nonincremental dep " + toString(dep));
                 continue;
             }
@@ -139,6 +139,10 @@ public class UpdateMojo extends AbstractVersionsDependencyUpdaterMojo {
             PropertyVersions versions = entry.getValue();
             String version = getProject().getProperties().getProperty(name);
             if (version == null) {
+                continue;
+            }
+            if (!updateNonincremental && !isIncremental(version)) {
+                getLog().debug("Skipping nonincremental ${" + name + "}=" + version);
                 continue;
             }
             List<String> ga = null; // [groupId, artifactId]
@@ -168,6 +172,10 @@ public class UpdateMojo extends AbstractVersionsDependencyUpdaterMojo {
                 PomHelper.setPropertyVersion(pom, versions.getProfileId(), name, result.version.toString());
             }
         }
+    }
+
+    private static boolean isIncremental(String version) {
+        return version.matches(".+-rc[0-9]+[.][0-9a-f]{12}");
     }
 
 }


### PR DESCRIPTION
For example `mvn incrementals:update -Dbranch=jglick:logs-JENKINS-38381` on https://github.com/jenkinsci/workflow-support-plugin/pull/15 inappropriately tried to patch

```diff
diff --git a/pom.xml b/pom.xml
index 41e178b..b06364b 100644
--- a/pom.xml
+++ b/pom.xml
@@ -68,10 +68,10 @@
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <useBeta>true</useBeta>
-        <git-plugin.version>3.7.0</git-plugin.version>
+        <git-plugin.version>4.0.0-beta3</git-plugin.version>
         <workflow-scm-step-plugin.version>2.6</workflow-scm-step-plugin.version>
-        <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
-        <scm-api-plugin.version>2.2.6</scm-api-plugin.version>
+        <workflow-step-api-plugin.version>2.16</workflow-step-api-plugin.version>
+        <scm-api-plugin.version>2.2.7</scm-api-plugin.version>
     </properties>
     <dependencies>
         <dependency>
```

in addition to the expected

```diff
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.30-rc808.1d2511e46e46</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/17 -->
+            <version>2.30-rc817.c9c8e89db14c</version> <!-- TODO https://github.com/jenkinsci/workflow-api-plugin/pull/17 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
```