### PR TITLE
Fixes offline instructions due to removal of incrementals.url property

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,25 +298,37 @@ docker run --rm --name nexus -p 8081:8081 -v nexus-data:/nexus-data sonatype/nex
 ```
 
 Log in to http://localhost:8081/ and pick an admin password as per instructions, then
-add to your `~/.m2/settings.xml`:
+edit your `~/.m2/settings.xml` to:
 
 ```xml
-<servers>
-  <server>
-    <id>incrementals</id>
-    <username>admin</username>
-    <password>admin123</password>
-  </server>
-</servers>
+<settings>
+  <servers>
+    <server>
+      <id>incrementals</id>
+      <username>admin</username>
+      <password>admin123</password>
+    </server>
+  </servers>
+  <mirrors>
+    <mirror>
+      <id>incrementals-mirror</id>
+      <url>http://localhost:8081/repository/maven-releases/</url>
+      <mirrorOf>incrementals</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>
 ```
 
-and then add to command lines consuming or producing incremental versions:
+and then add to the command line when producing incremental versions with [maven-deploy-plugin](https://maven.apache.org/plugins/maven-deploy-plugin/deploy-mojo.html):
 
 ```
--Dincrementals.url=http://localhost:8081/repository/maven-releases/
+-DaltDeploymentRepository=incrementals::http://localhost:8081/repository/maven-releases/
 ```
 
-or define an equivalent profile in local settings.
+or if using [maven-release-plugin](https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html):
+```
+-Darguments="-DaltDeploymentRepository=incrementals::http://localhost:8081/repository/maven-releases/"
+```
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -325,10 +325,6 @@ and then add to the command line when producing incremental versions with [maven
 -DaltDeploymentRepository=incrementals::http://localhost:8081/repository/maven-releases/
 ```
 
-or if using [maven-release-plugin](https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html):
-```
--Darguments="-DaltDeploymentRepository=incrementals::http://localhost:8081/repository/maven-releases/"
-```
 
 ## Changelog
 


### PR DESCRIPTION
This is due to Maven 4 support [1].

Building plugins with Maven 4 (alpha) fails with:
> 'profiles.profile[consume-incrementals].repositories.repository.[incrementals].url' contains an expression but should be a constant. @ org.jenkins-ci.plugins:plugin:4.53

This has already been reported to Jenkins [2] and Maven [3] and was declared as an intentional change.

[1] https://github.com/jenkinsci/plugin-pom/pull/666 
[2] https://issues.jenkins.io/browse/JENKINS-67878 
[3] https://issues.apache.org/jira/browse/MNG-7420

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
