### PR TITLE
Restore trailing slash after `a` or `b`

### DIFF
--- a/git-changelist-maven-extension/src/main/java/io/jenkins/tools/incrementals/git_changelist_maven_extension/Main.java
+++ b/git-changelist-maven-extension/src/main/java/io/jenkins/tools/incrementals/git_changelist_maven_extension/Main.java
@@ -173,7 +173,7 @@ public class Main extends AbstractMavenLifecycleParticipant {
     }
 
     static String sanitize(String hash) {
-        return hash.replaceAll("[ab]", "$0_").replaceAll("_$", "");
+        return hash.replaceAll("[ab]", "$0_");
     }
 
     private static String summarize(RevCommit c) {

--- a/git-changelist-maven-extension/src/test/java/io/jenkins/tools/incrementals/git_changelist_maven_extension/MainTest.java
+++ b/git-changelist-maven-extension/src/test/java/io/jenkins/tools/incrementals/git_changelist_maven_extension/MainTest.java
@@ -56,7 +56,7 @@ public class MainTest {
     @Test public void alphaBetaTrailing() {
         String hash = "852b473a2bcb";
         String sanitized = Main.sanitize(hash);
-        assertThat(hash + " has been sanitized to the expected format", sanitized, is("852b_473a_2b_cb"));
+        assertThat(hash + " has been sanitized to the expected format", sanitized, is("852b_473a_2b_cb_"));
         String canonical = new ComparableVersion(sanitized).getCanonical();
         for (String prerelease : PRERELEASE) {
             assertThat(sanitized + " treated as a prerelease", canonical, not(containsString(prerelease)));


### PR DESCRIPTION
Closes #34 by reverting the logic change in #31.