### PR TITLE
Refresh component for January 2023

### DIFF
--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -9,9 +9,15 @@
     <artifactId>incrementals-enforcer-rules</artifactId>
     <dependencies>
         <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.enforcer</groupId>
-            <artifactId>enforcer-rules</artifactId>
-            <version>3.0.0-M1</version>
+            <artifactId>enforcer-api</artifactId>
+            <version>3.2.1</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/enforcer-rules/src/main/java/io/jenkins/tools/incrementals/enforcer/RequireExtensionVersion.java
+++ b/enforcer-rules/src/main/java/io/jenkins/tools/incrementals/enforcer/RequireExtensionVersion.java
@@ -25,32 +25,60 @@
 package io.jenkins.tools.incrementals.enforcer;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.inject.Inject;
+import javax.inject.Named;
 import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
-import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
-import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.plugins.enforcer.AbstractVersionEnforcer;
+import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.util.StringUtils;
 
 /**
  * Verifies that {@code git-changelist-maven-extension}, if present, is sufficiently new.
  */
-public class RequireExtensionVersion extends AbstractVersionEnforcer {
+@Named("requireExtensionVersion")
+public class RequireExtensionVersion extends AbstractEnforcerRule {
 
     private static final Pattern ID_PATTERN = Pattern.compile("\\QcoreExtension>io.jenkins.tools.incrementals:git-changelist-maven-extension:\\E(.+)");
 
+    /**
+     * Specify the required version. Some examples are:
+     * <ul>
+     * <li><code>2.0.4</code> Version 2.0.4 and higher (different from Maven meaning)</li>
+     * <li><code>[2.0,2.1)</code> Versions 2.0 (included) to 2.1 (not included)</li>
+     * <li><code>[2.0,2.1]</code> Versions 2.0 to 2.1 (both included)</li>
+     * <li><code>[2.0.5,)</code> Versions 2.0.5 and higher</li>
+     * <li><code>(,2.0.5],[2.1.1,)</code> Versions up to 2.0.5 (included) and 2.1.1 or higher</li>
+     * </ul>
+     *
+     * @see {@link #setVersion(String)}
+     * @see {@link #getVersion()}
+     */
+    private String version;
+
+    private final PlexusContainer container;
+
+    @Inject
+    public RequireExtensionVersion(PlexusContainer container) {
+        this.container = Objects.requireNonNull(container);
+    }
+
     @Override
-    public void execute(EnforcerRuleHelper erh) throws EnforcerRuleException {
-        Log log = erh.getLog();
+    public void execute() throws EnforcerRuleException {
         List<AbstractMavenLifecycleParticipant> participants;
         try {
-            participants = erh.getContainer().lookupList(AbstractMavenLifecycleParticipant.class);
+            participants = container.lookupList(AbstractMavenLifecycleParticipant.class);
         } catch (ComponentLookupException x) {
-            log.warn(x);
+            getLog().warn(x.getMessage());
             return;
         }
         for (AbstractMavenLifecycleParticipant participant : participants) {
@@ -59,10 +87,113 @@ public class RequireExtensionVersion extends AbstractVersionEnforcer {
             if (loader instanceof ClassRealm) {
                 Matcher m = ID_PATTERN.matcher(((ClassRealm) loader).getId());
                 if (m.matches()) {
-                    enforceVersion(log, "git-changelist-maven-extension", getVersion(), new DefaultArtifactVersion(m.group(1)));
+                    enforceVersion("git-changelist-maven-extension", getVersion(), new DefaultArtifactVersion(m.group(1)));
                 }
             }
         }
     }
 
+    /**
+     * Compares the specified version to see if it is allowed by the defined version range.
+     *
+     * @param variableName         name of variable to use in messages (Example: "Maven" or "Java" etc).
+     * @param requiredVersionRange range of allowed versions.
+     * @param actualVersion        the version to be checked.
+     * @throws EnforcerRuleException the enforcer rule exception
+     */
+    // CHECKSTYLE_OFF: LineLength
+    private void enforceVersion(String variableName, String requiredVersionRange, ArtifactVersion actualVersion)
+            throws EnforcerRuleException
+    // CHECKSTYLE_ON: LineLength
+    {
+        if (StringUtils.isEmpty(requiredVersionRange)) {
+            throw new EnforcerRuleException(variableName + " version can't be empty.");
+        } else {
+
+            VersionRange vr;
+            String msg = "Detected " + variableName + " Version: " + actualVersion;
+
+            // short circuit check if the strings are exactly equal
+            if (actualVersion.toString().equals(requiredVersionRange)) {
+                getLog().debug(msg + " is allowed in the range " + requiredVersionRange + ".");
+            } else {
+                try {
+                    vr = VersionRange.createFromVersionSpec(requiredVersionRange);
+
+                    if (containsVersion(vr, actualVersion)) {
+                        getLog().debug(msg + " is allowed in the range " + toString(vr) + ".");
+                    } else {
+                        throw new EnforcerRuleException(msg + " is not in the allowed range " + toString(vr) + ".");
+                    }
+                } catch (InvalidVersionSpecificationException e) {
+                    throw new EnforcerRuleException(
+                            "The requested " + variableName + " version " + requiredVersionRange + " is invalid.", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Copied from Artifact.VersionRange. This is tweaked to handle singular ranges properly. Currently the default
+     * containsVersion method assumes a singular version means allow everything. This method assumes that "2.0.4" ==
+     * "[2.0.4,)"
+     *
+     * @param allowedRange range of allowed versions.
+     * @param theVersion   the version to be checked.
+     * @return true if the version is contained by the range.
+     */
+    private static boolean containsVersion(VersionRange allowedRange, ArtifactVersion theVersion) {
+        ArtifactVersion recommendedVersion = allowedRange.getRecommendedVersion();
+        if (recommendedVersion == null) {
+            return allowedRange.containsVersion(theVersion);
+        } else {
+            // only singular versions ever have a recommendedVersion
+            int compareTo = recommendedVersion.compareTo(theVersion);
+            return (compareTo <= 0);
+        }
+    }
+
+    private static String toString(VersionRange vr) {
+        // as recommended version is used as lower bound in this context modify the string representation
+        if (vr.getRecommendedVersion() != null) {
+            return "[" + vr.getRecommendedVersion().toString() + ",)";
+        } else {
+            return vr.toString();
+        }
+    }
+
+    @Override
+    public String getCacheId() {
+        if (StringUtils.isNotEmpty(version)) {
+            // return the hashcodes of the parameter that matters
+            return "" + version.hashCode();
+        } else {
+            return "0";
+        }
+    }
+
+    /**
+     * Gets the required version.
+     *
+     * @return the required version
+     */
+    public final String getVersion() {
+        return this.version;
+    }
+
+    /**
+     * Specify the required version. Some examples are:
+     * <ul>
+     * <li><code>2.0.4</code> Version 2.0.4 and higher (different from Maven meaning)</li>
+     * <li><code>[2.0,2.1)</code> Versions 2.0 (included) to 2.1 (not included)</li>
+     * <li><code>[2.0,2.1]</code> Versions 2.0 to 2.1 (both included)</li>
+     * <li><code>[2.0.5,)</code> Versions 2.0.5 and higher</li>
+     * <li><code>(,2.0.5],[2.1.1,)</code> Versions up to 2.0.5 (included) and 2.1.1 or higher</li>
+     * </ul>
+     *
+     * @param theVersion the required version to set
+     */
+    public void setVersion(String theVersion) {
+        this.version = theVersion;
+    }
 }

--- a/git-changelist-maven-extension/pom.xml
+++ b/git-changelist-maven-extension/pom.xml
@@ -14,7 +14,7 @@
             <plugin>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-component-metadata</artifactId>
-                <version>1.7.1</version>
+                <version>2.1.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -9,10 +9,16 @@
     <artifactId>lib</artifactId>
     <dependencies>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <version>3.0.2</version>
-            <scope>provided</scope>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>4.7.3</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/lib/src/main/java/io/jenkins/tools/incrementals/lib/UpdateChecker.java
+++ b/lib/src/main/java/io/jenkins/tools/incrementals/lib/UpdateChecker.java
@@ -34,7 +34,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.annotation.CheckForNull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.kohsuke.github.GHCompare;

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -8,6 +8,9 @@
     </parent>
     <artifactId>incrementals-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
+    <properties>
+        <maven-plugin-tools.version>3.7.1</maven-plugin-tools.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -17,30 +20,61 @@
         <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>versions-maven-plugin</artifactId>
-            <version>2.5</version>
+            <version>2.14.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.5.1</version>
+            <version>${maven-plugin-tools.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.twdata.maven</groupId>
             <artifactId>mojo-executor</artifactId>
-            <version>2.3.0</version>
+            <version>2.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <version>3.0.2</version>
-            <scope>provided</scope>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>4.7.3</version>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>
@@ -49,7 +83,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>${maven-plugin-tools.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/util/PluginRef.java
+++ b/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/util/PluginRef.java
@@ -25,8 +25,8 @@ package io.jenkins.tools.incrementals.maven.util;
 
 import org.apache.maven.model.Dependency;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 
 /**
@@ -100,7 +100,7 @@ public class PluginRef {
         return artifactId + (version != null ? (":" + version) : "");
     }
 
-    @Nonnull
+    @NonNull
     public String toPluginsTxtString() {
         if (comment != null) {
             return comment;
@@ -121,19 +121,19 @@ public class PluginRef {
         return artifactId + (label != null ? (":" + label) : "");
     }
 
-    @Nonnull
-    public static PluginRef forComment(@Nonnull String line) throws IOException {
+    @NonNull
+    public static PluginRef forComment(@NonNull String line) throws IOException {
         PluginRef ref = new PluginRef();
         ref.comment = line;
         return ref;
     }
 
-    public void setVersion(@Nonnull String version) {
+    public void setVersion(@NonNull String version) {
         this.version = version;
     }
 
-    @Nonnull
-    public static PluginRef fromString(@Nonnull String str) throws IOException {
+    @NonNull
+    public static PluginRef fromString(@NonNull String str) throws IOException {
         String[] entries = str.split(":");
         if (entries.length == 0) {
             throw new IOException("Version string is corrupted: " + str);
@@ -174,7 +174,7 @@ public class PluginRef {
         return plugin;
     }
 
-    @Nonnull
+    @NonNull
     public Dependency toDependency() {
         Dependency dep = new Dependency();
         dep.setArtifactId(artifactId);

--- a/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/util/PluginRefList.java
+++ b/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/util/PluginRefList.java
@@ -27,7 +27,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.model.Dependency;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -57,7 +57,7 @@ public class PluginRefList extends ArrayList<PluginRef> {
         return plugins;
     }
 
-    @Nonnull
+    @NonNull
     public List<Dependency> toDependencyList() {
         List<Dependency> depList = new ArrayList<>(this.size());
         for (PluginRef plugin : this) {
@@ -67,7 +67,7 @@ public class PluginRefList extends ArrayList<PluginRef> {
     }
 
 
-    public void writeToFile(@Nonnull File dest) throws IOException {
+    public void writeToFile(@NonNull File dest) throws IOException {
         List<String> outputLines = new ArrayList<>(this.size());
         for (PluginRef ref : this) {
             outputLines.add(ref.toPluginsTxtString());

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.version>3.5.0</maven.version>
+        <maven.version>3.9.0</maven.version>
     </properties>
     <modules>
         <module>lib</module>
@@ -62,6 +62,11 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-artifact</artifactId>
+                <version>${maven.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-compat</artifactId>
                 <version>${maven.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
See https://github.com/jenkinsci/pom/pull/387 and https://github.com/jenkinsci/plugin-pom/pull/689. We cannot update Maven Enforcer Plugin to the latest version until this component is recompiled against recent Maven APIs.

I tested each component manually (with Enforcer 3.2.1):

- `RequireExtensionVersion` with valid version
- `RequireExtensionVersion` with invalid version
- Unincrementalified a plugin, stepped through the modified code in `IncrementalifyMojo` in a debugger, verified the changes to `pom.xml` were as expected
- Stepped through the modified code in `UpdateMojo` in a debugger, verified the mojo completed without any errors
- Jenkins core build with these changes
- Text Finder plugin build with these changes

CC @jglick