### PR TITLE
set maven libs according to consumers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "github-actions"
+    ignore:
+      # maven core artifacts are provided by the running maven, do not update to prevent consuming something unavailable
+      - dependency-name: "org.apache.maven:*"
+ - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -11,6 +11,11 @@
     <properties>
         <maven-plugin-tools.version>3.7.1</maven-plugin-tools.version>
     </properties>
+
+    <prerequisites>
+        <maven>${maven.version}</maven>
+    </prerequisites>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.version>3.9.0</maven.version>
+        <maven.version>3.8.1</maven.version>
     </properties>
     <modules>
         <module>lib</module>


### PR DESCRIPTION
use a version of maven libs that we expect to be satisfied by consumers.

cf https://github.com/jenkinsci/maven-hpi-plugin/pull/440#issuecomment-1454825697

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
