### PR TITLE
Add an URL per component

### DIFF
--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -6,6 +6,7 @@
         <artifactId>parent</artifactId>
         <version>1.7-SNAPSHOT</version>
     </parent>
+    <url>https://github.com/jenkinsci/incrementals-tools/tree/master/enforcer-rules</url>
     <artifactId>incrementals-enforcer-rules</artifactId>
     <dependencies>
         <dependency>

--- a/git-changelist-maven-extension/pom.xml
+++ b/git-changelist-maven-extension/pom.xml
@@ -9,6 +9,7 @@
     <artifactId>git-changelist-maven-extension</artifactId>
     <name>Git Changelist Maven Extension</name>
     <description>Maven extension which can set the special changelist user property according to Git metadata.</description>
+    <url>https://github.com/jenkinsci/incrementals-tools/tree/master/git-changelist-maven-extension</url>
     <build>
         <plugins>
             <plugin>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -7,6 +7,7 @@
         <version>1.7-SNAPSHOT</version>
     </parent>
     <artifactId>lib</artifactId>
+    <url>https://github.com/jenkinsci/incrementals-tools/tree/master/lib</url>
     <dependencies>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -8,6 +8,7 @@
     </parent>
     <artifactId>incrementals-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
+    <url>https://github.com/jenkinsci/incrementals-tools/tree/master/maven-plugin</url>
     <properties>
         <maven-plugin-tools.version>3.8.1</maven-plugin-tools.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <packaging>pom</packaging>
     <name>Incrementals Tools POM</name>
     <description>Tools for working with JEP-305 “Incrementals”.</description>
+    <url>https://github.com/jenkinsci/incrementals-tools</url>
     <licenses>
         <license>
             <name>MIT License</name>


### PR DESCRIPTION
When automatic dependency updaters create PRs, like https://github.com/jenkinsci/ionicons-api-plugin/pull/46, they tend to pick up `kohsuke.org` as the repository URL of the component because these are the coordinates from the parent pom.

The change proposed adds an `<url>` to each component to address this issue.