### PR TITLE
Fix javadoc errors on java 20

### DIFF
--- a/enforcer-rules/src/main/java/io/jenkins/tools/incrementals/enforcer/RequireExtensionVersion.java
+++ b/enforcer-rules/src/main/java/io/jenkins/tools/incrementals/enforcer/RequireExtensionVersion.java
@@ -60,8 +60,8 @@ public class RequireExtensionVersion extends AbstractEnforcerRule {
      * <li><code>(,2.0.5],[2.1.1,)</code> Versions up to 2.0.5 (included) and 2.1.1 or higher</li>
      * </ul>
      *
-     * @see {@link #setVersion(String)}
-     * @see {@link #getVersion()}
+     * @see #setVersion(String)
+     * @see #getVersion()
      */
     private String version;
 

--- a/lib/src/main/java/io/jenkins/tools/incrementals/lib/UpdateChecker.java
+++ b/lib/src/main/java/io/jenkins/tools/incrementals/lib/UpdateChecker.java
@@ -161,7 +161,6 @@ public final class UpdateChecker {
 
     /**
      * Look for all known versions of a given artifact.
-     * @param repos a set of repository URLs to check
      * @return a possibly empty set of versions, sorted descending
      */
     private SortedSet<VersionAndRepo> loadVersions(String groupId, String artifactId) throws Exception {


### PR DESCRIPTION
Javadoc generation failed on Java 20 for me, because javadoc got stricter since Java 8. The change proposed addresses the warnings and errors.