### PR TITLE
Bump org.eclipse.jgit from 4.9.0.201710071750-r to 6.5.0.202303070854-r

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
   ignore:
   # maven core artifacts are provided by the running maven, do not update to prevent consuming something unavailable
   - dependency-name: org.apache.maven:*
+  # jgit 6 requires Java 11
+  - dependency-name: "org.eclipse.jgit:org.eclipse.jgit"
+    versions: [ ">=6.0.0.202111291000-r" ]
 - package-ecosystem: github-actions
   directory: /
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
   ignore:
   # maven core artifacts are provided by the running maven, do not update to prevent consuming something unavailable
   - dependency-name: org.apache.maven:*
-  # jgit 6 requires Java 11
-  - dependency-name: "org.eclipse.jgit:org.eclipse.jgit"
-    versions: [ ">=6.0.0.202111291000-r" ]
 - package-ecosystem: github-actions
   directory: /
   schedule:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,13 +5,17 @@ on:
       - master
 jobs:
   build:
+    strategy:
+      matrix:
+        java: ["11", "17"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        java-version: "${{ matrix.java }}"
+        distribution: temurin
     - name: Build with Maven
       run: mvn -B -V -ntp -Dstyle.color=always package
       env:

--- a/git-changelist-maven-extension/pom.xml
+++ b/git-changelist-maven-extension/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>4.9.0.201710071750-r</version>
+            <version>5.13.1.202206130422-r</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/git-changelist-maven-extension/pom.xml
+++ b/git-changelist-maven-extension/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>5.13.1.202206130422-r</version>
+            <version>6.5.0.202303070854-r</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Like https://github.com/jenkinsci/incrementals-tools/pull/49, but pinning v5 because v6 requires Java 11 or newer and this tool's GH action is bound to Java 8.

Closes https://github.com/jenkinsci/incrementals-tools/pull/49
Closes https://github.com/jenkinsci/incrementals-tools/pull/39