### PR TITLE
Migrate from deprecated Plexus Components to non-deprecated JSR 330

### DIFF
--- a/git-changelist-maven-extension/pom.xml
+++ b/git-changelist-maven-extension/pom.xml
@@ -12,13 +12,14 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-component-metadata</artifactId>
-                <version>2.1.1</version>
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>sisu-maven-plugin</artifactId>
+                <version>0.3.5</version>
                 <executions>
                     <execution>
+                        <id>generate-index</id>
                         <goals>
-                            <goal>generate-metadata</goal>
+                            <goal>main-index</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/git-changelist-maven-extension/src/main/java/io/jenkins/tools/incrementals/git_changelist_maven_extension/Main.java
+++ b/git-changelist-maven-extension/src/main/java/io/jenkins/tools/incrementals/git_changelist_maven_extension/Main.java
@@ -36,12 +36,13 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
 import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.logging.Logger;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.Status;
@@ -59,13 +60,14 @@ import org.eclipse.jgit.revwalk.RevWalk;
  * @see <a href="https://maven.apache.org/maven-ci-friendly.html">Maven CI Friendly Versions</a>
  * @see <a href="https://maven.apache.org/docs/3.3.1/release-notes.html#Core_Extensions">Core Extensions</a>
  */
-@Component(role=AbstractMavenLifecycleParticipant.class, hint="git-changelist-maven-extension")
+@Named("git-changelist-maven-extension")
+@Singleton
 public class Main extends AbstractMavenLifecycleParticipant {
 
     private static final String IGNORE_DIRT = "ignore.dirt";
     private static final int ABBREV_LENGTH = 12;
 
-    @Requirement
+    @Inject
     private Logger log;
 
     @Override


### PR DESCRIPTION
References:

- https://cwiki.apache.org/confluence/display/MAVEN/Maven+Ecosystem+Cleanup
- https://maven.apache.org/maven-jsr330.html
- https://github.com/eclipse/sisu.plexus/wiki/Plexus-to-JSR330

### Testing done

Ran a build of Text Finder with `-Dset.changelist` and these changes.

Fixes #62