### PR TITLE
Revert "Merge pull request #64 from jenkinsci/dependabot/maven/org.codehaus.mojo-versions-maven-plugin-2.16.0"

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>versions-maven-plugin</artifactId>
-            <version>2.16.0</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
#64 seems to break tests _locally_ for some reason. (But not on CI, which is still using Maven 3.8.8.)

```console
$ mvn -pl maven-plugin surefire:test
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO] 
[INFO] ------< io.jenkins.tools.incrementals:incrementals-maven-plugin >-------
[INFO] Building incrementals-maven-plugin 1.7-SNAPSHOT
[INFO]   from pom.xml
[INFO] ----------------------------[ maven-plugin ]----------------------------
[INFO] 
[INFO] --- surefire:3.1.2:test (default-cli) @ incrementals-maven-plugin ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.486 s
[INFO] Finished at: 2023-06-29T16:42:59-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.1.2:test (default-cli) on project incrementals-maven-plugin: Execution default-cli of goal org.apache.maven.plugins:maven-surefire-plugin:3.1.2:test failed: org.junit.platform.commons.JUnitException: TestEngine with ID 'junit-vintage' failed to discover tests: Unsupported version of junit:junit: 3.8.1. Please upgrade to version 4.12 or later. -> [Help 1]
```

Tree:

```
[INFO] +- org.codehaus.mojo:versions-maven-plugin:jar:2.16.0:compile
[INFO] |  +- org.codehaus.mojo.versions:versions-model:jar:2.16.0:compile
[INFO] |  +- org.codehaus.mojo.versions:versions-model-report:jar:2.16.0:compile
[INFO] |  +- org.codehaus.mojo.versions:versions-common:jar:2.16.0:compile
[INFO] |  |  +- org.codehaus.mojo.versions:versions-api:jar:2.16.0:compile
[INFO] |  |  \- org.apache.commons:commons-collections4:jar:4.4:compile
[INFO] |  +- org.apache.maven.reporting:maven-reporting-impl:jar:3.2.0:compile
[INFO] |  |  +- org.apache.maven.reporting:maven-reporting-api:jar:3.1.1:compile
[INFO] |  |  +- org.apache.maven.doxia:doxia-decoration-model:jar:1.11.1:compile
[INFO] |  |  \- org.apache.maven.doxia:doxia-integration-tools:jar:1.11.1:compile
[INFO] |  |     \- org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9:compile
[INFO] |  |        +- junit:junit:jar:3.8.1:compile
```

Somehow related to #60.