### PR TITLE
Fixup bad merge in #72

### DIFF
--- a/git-changelist-maven-extension/pom.xml
+++ b/git-changelist-maven-extension/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
+            <artifactId>hamcrest</artifactId>
             <version>2.2</version>
             <scope>test</scope>
         </dependency>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -78,7 +78,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
+            <artifactId>hamcrest</artifactId>
             <version>2.2</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Looks like something went wrong when I updated my fork.

https://github.com/jenkinsci/incrementals-tools/pull/72/files#diff-5b09e4f9360590e6d4eab0d4b50393fb060ce2dcf7d889f154a99a1830c3c7bbR81 is not supposed to be here.

The change proposed reverts the bad merge.