### PR TITLE
Add missing names

### DIFF
--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -7,6 +7,7 @@
         <version>1.10-SNAPSHOT</version>
     </parent>
     <artifactId>incrementals-enforcer-rules</artifactId>
+    <name>Incrementals Enforcer Rules</name>
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -7,6 +7,7 @@
         <version>1.10-SNAPSHOT</version>
     </parent>
     <artifactId>lib</artifactId>
+    <name>Incrementals Library</name>
     <dependencies>
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -7,6 +7,7 @@
         <version>1.10-SNAPSHOT</version>
     </parent>
     <artifactId>incrementals-maven-plugin</artifactId>
+    <name>Incrementals Maven Plugin</name>
     <packaging>maven-plugin</packaging>
     <properties>
         <maven-plugin-tools.version>3.15.1</maven-plugin-tools.version>


### PR DESCRIPTION
When attempting to publish the last release to Maven Central:

```
[INFO] Deployment failed
[INFO] pkg:maven/io.jenkins.tools.incrementals/lib@1.9:
[INFO]  - Project name is missing
[INFO]
[INFO] pkg:maven/io.jenkins.tools.incrementals/incrementals-enforcer-rules@1.9:
[INFO]  - Project name is missing
[INFO]
[INFO] pkg:maven/io.jenkins.tools.incrementals/incrementals-maven-plugin@1.9:
[INFO]  - Project name is missing
```