### PR TITLE
Reduce usages of third-party libraries

### DIFF
--- a/lib/src/main/java/io/jenkins/tools/incrementals/lib/UpdateChecker.java
+++ b/lib/src/main/java/io/jenkins/tools/incrementals/lib/UpdateChecker.java
@@ -266,7 +266,7 @@ public final class UpdateChecker {
             throw new IllegalStateException("Usage: java " + UpdateChecker.class.getName() + " <groupId> <artifactId> <currentVersion> <branch>");
         }
         VersionAndRepo result = new UpdateChecker(
-                message -> System.err.println(message),
+                System.err::println,
                 Arrays.asList("https://repo.jenkins-ci.org/releases/", "https://repo.jenkins-ci.org/incrementals/")).
             find(argv[0], argv[1], argv[2], argv[3]);
         if (result != null) {

--- a/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/DependencyManagementMojo.java
+++ b/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/DependencyManagementMojo.java
@@ -13,19 +13,19 @@ public interface DependencyManagementMojo {
         buf.append(d.getGroupId());
         buf.append(':');
         buf.append(d.getArtifactId());
-        if (d.getType() != null && d.getType().length() > 0) {
+        if (d.getType() != null && !d.getType().isEmpty()) {
             buf.append(':');
             buf.append(d.getType());
         } else {
             buf.append(":jar");
         }
 
-        if (d.getClassifier() != null && d.getClassifier().length() > 0) {
+        if (d.getClassifier() != null && !d.getClassifier().isEmpty()) {
             buf.append(':');
             buf.append(d.getClassifier());
         }
 
-        if (d.getVersion() != null && d.getVersion().length() > 0) {
+        if (d.getVersion() != null && !d.getVersion().isEmpty()) {
             buf.append(":");
             buf.append(d.getVersion());
         }

--- a/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/DetectIndent.java
+++ b/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/DetectIndent.java
@@ -1,11 +1,9 @@
 package io.jenkins.tools.incrementals.maven;
 
-import org.apache.commons.lang3.StringUtils;
-
 public class DetectIndent {
 
   public Indent detect(String input) {
-    if (StringUtils.isNotEmpty(input)) {
+    if (input != null && !input.isEmpty()) {
       int size = 0;
       char indent = ' ';
       String[] inputs = input.split("(\r\n|\r|\n)");
@@ -31,7 +29,7 @@ public class DetectIndent {
     return new Indent();
   }
 
-  public class Indent {
+  public static class Indent {
     int size = 0;
     char type = ' ';
 
@@ -44,7 +42,7 @@ public class DetectIndent {
     }
 
     public String getIndent() {
-      return StringUtils.repeat(String.valueOf(type), size);
+      return String.valueOf(type).repeat(size);
     }
 
     public int getSize() {

--- a/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/util/PluginRefList.java
+++ b/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/util/PluginRefList.java
@@ -23,8 +23,6 @@
  */
 package io.jenkins.tools.incrementals.maven.util;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.model.Dependency;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -32,6 +30,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,7 +45,7 @@ public class PluginRefList extends ArrayList<PluginRef> {
         PluginRefList plugins = new PluginRefList();
         try(BufferedReader br = new BufferedReader(new FileReader(file))) {
             for(String line; (line = br.readLine()) != null; ) {
-                if (StringUtils.isBlank(line) || line.startsWith("#")) {
+                if (line.isBlank() || line.startsWith("#")) {
                     plugins.add(PluginRef.forComment(line));
                 } else {
                     plugins.add(PluginRef.fromString(line));
@@ -73,6 +72,6 @@ public class PluginRefList extends ArrayList<PluginRef> {
             outputLines.add(ref.toPluginsTxtString());
         }
 
-        FileUtils.writeLines(dest, outputLines);
+        Files.writeString(dest.toPath(), String.join("\n", outputLines));
     }
 }


### PR DESCRIPTION
Use native Java Platform equivalents instead to reduce maintenance costs. Also fix some other IDE warnings while I was here.