### PR TITLE
Fix `EmptyStackException` in `IncrementalifyMojo`

### DIFF
--- a/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/IncrementalifyMojo.java
+++ b/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/IncrementalifyMojo.java
@@ -230,7 +230,7 @@ public class IncrementalifyMojo extends AbstractVersionsUpdaterMojo {
                     }
                 }
             }
-            if ( pom.isEndElement() )
+            else if ( pom.isEndElement() )
             {
                 path = stack.pop();
             }


### PR DESCRIPTION
At some point in the past few releases, `IncrementalifyMojo` seems to have been broken. It currently fails with:

```
java.util.EmptyStackException
    at java.util.Stack.peek (Stack.java:103)
    at java.util.Stack.pop (Stack.java:85)
    at io.jenkins.tools.incrementals.maven.IncrementalifyMojo.getProjectParent (IncrementalifyMojo.java:235)
    at io.jenkins.tools.incrementals.maven.IncrementalifyMojo.update (IncrementalifyMojo.java:149)
    at org.codehaus.mojo.versions.AbstractVersionsUpdaterMojo.process (AbstractVersionsUpdaterMojo.java:316)
    at org.codehaus.mojo.versions.AbstractVersionsUpdaterMojo.execute (AbstractVersionsUpdaterMojo.java:271)
    at io.jenkins.tools.incrementals.maven.IncrementalifyMojo.execute (IncrementalifyMojo.java:119)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:261)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:906)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:206)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
```

### Testing done

Reproduced the problem trying to incrementalify an unincrementalified plugin. Could no longer reproduce after this PR.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
