### PR TITLE
Upgrade `versions-maven-plugin` from 2.5 to 2.19.0

### DIFF
--- a/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/IncrementalifyMojo.java
+++ b/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/IncrementalifyMojo.java
@@ -118,7 +118,7 @@ public class IncrementalifyMojo extends AbstractVersionsUpdaterMojo {
         ArtifactVersion gclmeNewestVersion = gclmeVersions.getNewestVersion(any, false);
         super.execute();
         project.getProperties().setProperty("dollar", "$");
-        executeMojo(plugin("org.codehaus.mojo", "versions-maven-plugin", "2.5"), "set",
+        executeMojo(plugin("org.codehaus.mojo", "versions-maven-plugin", "2.19.0"), "set",
             configuration(
                 element("newVersion", "${dollar}{revision}${dollar}{changelist}"),
                 element("generateBackupPoms", "false")),

--- a/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/ReincrementalifyMojo.java
+++ b/maven-plugin/src/main/java/io/jenkins/tools/incrementals/maven/ReincrementalifyMojo.java
@@ -69,12 +69,12 @@ public class ReincrementalifyMojo extends AbstractMojo {
             throw new MojoFailureException("Unexpected version: " + version);
         }
         properties.setProperty("dollar", "$");
-        executeMojo(plugin("org.codehaus.mojo", "versions-maven-plugin", "2.5"), "set",
+        executeMojo(plugin("org.codehaus.mojo", "versions-maven-plugin", "2.19.0"), "set",
             configuration(
                 element("newVersion", "${dollar}{revision}${dollar}{changelist}"),
                 element("generateBackupPoms", "false")),
             executionEnvironment(project, mavenSession, pluginManager));
-        executeMojo(plugin("org.codehaus.mojo", "versions-maven-plugin", "2.5"), "set-property",
+        executeMojo(plugin("org.codehaus.mojo", "versions-maven-plugin", "2.19.0"), "set-property",
             configuration(
                 element("property", "revision"),
                 element("newVersion", m.group(1)),


### PR DESCRIPTION
Could probably be automated with Renovate, but that is explicitly not being done in this PR.